### PR TITLE
1-add-methods-to-get-the-last-form-value-filled-by-the-user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New method `storeOldRequestValues()` to store form values (and being able to retreive them later).
+- New method `getOldRequestValue("email")` to get a previously submitted form value.
+
 ## [0.2.0] 2020-09-06
 
 ### Breaking

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Here is [the content](https://github.com/laravel/laravel/blob/v7.25.0/resources/
 - [5. Check if a request validation succeeded](#5-check-if-a-request-validation-succeeded)
 - [6. Get error messages after a request validation](#6-get-error-messages-after-a-request-validation)
 - [7. Choosing the validation error language before validating request](#7-choosing-the-validation-error-language-before-validating-request)
+- [8. Get an old submited form value](#8-get-an-old-submited-form-value)
 
 ### 1. Get a request value by its key
 
@@ -187,6 +188,26 @@ use function Folded\setRequestValidationTranslationFolderPath;
 setRequestValidationTranslationFolderPath(__DIR__ . "/lang");
 setRequestValidationLang("fr");
 ```
+
+### 8. Get an old submited form value
+
+In this example, we will get a previously submitted form value. This is convenient if you want to display values the user used before an error occured (in order for the user to not loose everything he wrote).
+
+```php
+use function Folded\storeOldRequestValues;
+use function Folded\getOldRequestValue;
+
+// Session must be enabled to make it work
+session_start();
+
+// As soon as possible
+storeOldRequestValues();
+
+// Get the old form values, assuming you previously listened a POST request with an email key
+echo getOldRequestValue("email");
+```
+
+If the key is not found, the `getOldRequestValue()` function returns `null`.
 
 ## Version support
 

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,9 @@
             "src/hasRequestValue.php",
             "src/requestValidationSucceeded.php",
             "src/setRequestValidationTranslationFolderPath.php",
-            "src/validateRequest.php"
+            "src/validateRequest.php",
+            "src/getOldRequestValue.php",
+            "src/storeOldRequestValues.php"
         ]
     },
     "require-dev": {

--- a/src/getOldRequestValue.php
+++ b/src/getOldRequestValue.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Folded;
+
+if (!function_exists("getOldRequestValue")) {
+    /**
+     * Get the old value of a previously submited form.
+     *
+     * @param string $key The name of the key holding the form value.
+     *
+     * @throws Exception If sessions are not enabled yet.
+     *
+     * @return null|mixed
+     *
+     * @since 0.3.0
+     *
+     * @example
+     * echo getOldRequestValue("email");
+     */
+    function getOldRequestValue(string $key)
+    {
+        return Request::getOldValue($key);
+    }
+}

--- a/src/storeOldRequestValues.php
+++ b/src/storeOldRequestValues.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Folded;
+
+if (!function_exists("storeOldRequestValues")) {
+    /**
+     * Stores old forms values in session for further retrieval.
+     *
+     * @throws Exception If sessions are not started.
+     *
+     * @since 0.3.0
+     *
+     * @example
+     * storeOldRequestValues();
+     */
+    function storeOldRequestValues(): void
+    {
+        Request::storeOldValues();
+    }
+}

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -4,9 +4,20 @@ declare(strict_types = 1);
 
 use Folded\Request;
 
+function activateSession(): void
+{
+    if (session_status() !== PHP_SESSION_ACTIVE) {
+        session_start();
+    }
+}
+
 beforeEach(function (): void {
     Request::clear();
     $_POST = [];
+
+    if (session_status() === PHP_SESSION_ACTIVE) {
+        session_destroy();
+    }
 });
 
 it("should return the request value", function (): void {
@@ -39,4 +50,41 @@ it("should return false if the request is not present", function (): void {
     $_POST["search"] = "foo";
 
     expect(Request::hasValue("filter"))->toBeFalse();
+});
+
+it("should return the old request value", function (): void {
+    $email = "contact@example.com";
+
+    $_SERVER["REQUEST_METHOD"] = "POST";
+    $_POST["email"] = $email;
+
+    activateSession();
+
+    Request::storeOldValues();
+
+    expect(Request::getOldValue("email"))->toBe($email);
+});
+
+it("should throw an exception if the session is not started before getting an old value", function (): void {
+    $this->expectException(Exception::class);
+
+    Request::getOldValue("foo");
+});
+
+it("should throw an exception message if the session is not started before getting an old value", function (): void {
+    $this->expectExceptionMessage("session not started");
+
+    Request::getOldValue("foo");
+});
+
+it("should throw an exception if session is not started before storing old values", function (): void {
+    $this->expectException(Exception::class);
+
+    Request::storeOldValues();
+});
+
+it("should throw an exception message if session is not started before storing old values", function (): void {
+    $this->expectExceptionMessage("session not started");
+
+    Request::storeOldValues();
 });

--- a/tests/getOldRequestValueTest.php
+++ b/tests/getOldRequestValueTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types = 1);
+
+use Folded\Request;
+use function Folded\getOldRequestValue;
+use function Folded\storeOldRequestValues;
+
+beforeEach(function (): void {
+    Request::clear();
+    $_POST = [];
+
+    if (session_status() !== PHP_SESSION_ACTIVE) {
+        session_start();
+    }
+});
+
+it("should get the old value", function (): void {
+    $key = "email";
+    $value = "contact@example.com";
+
+    $_SERVER["REQUEST_METHOD"] = "POST";
+    $_POST[$key] = $value;
+
+    storeOldRequestValues();
+
+    expect(getOldRequestValue($key))->toBe($value);
+});

--- a/tests/storeOldRequestValuesTest.php
+++ b/tests/storeOldRequestValuesTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types = 1);
+
+use Folded\Request;
+use function Folded\storeOldRequestValues;
+
+beforeEach(function (): void {
+    Request::clear();
+    $_POST = [];
+
+    if (session_status() !== PHP_SESSION_ACTIVE) {
+        session_start();
+    }
+});
+
+it("should store old values", function (): void {
+    $data = [
+        "email" => "contact@example.com",
+    ];
+
+    $_SERVER["REQUEST_METHOD"] = "POST";
+    $_POST = $data;
+
+    storeOldRequestValues();
+
+    expect($_SESSION["__folded_old_values"])->toBe($data);
+});


### PR DESCRIPTION
## Added 

- New method `storeOldRequestValues()` to store old form submitted values in session.
- New method `getOldRequestValue("key")` to get a value from the old submitted form values.

## Fixed

None.

## Breaking

None.