### PR TITLE
6-missing-namespace-in-function-exists-call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Added missing namespace `Folded` in the `function_exists` statements.
+
 ## [0.3.1] 2020-09-22
 
 ### Fixed

--- a/src/getAllRequestValues.php
+++ b/src/getAllRequestValues.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("getAllRequestValues")) {
+if (!function_exists("Folded\getAllRequestValues")) {
     /**
      * Get all the values in the request data.
      *

--- a/src/getOldRequestValue.php
+++ b/src/getOldRequestValue.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("getOldRequestValue")) {
+if (!function_exists("Folded\getOldRequestValue")) {
     /**
      * Get the old value of a previously submited form.
      *

--- a/src/getRequestValidationErrors.php
+++ b/src/getRequestValidationErrors.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("getRequestValidationErrors")) {
+if (!function_exists("Folded\getRequestValidationErrors")) {
     /**
      * Returns an object that is traversable, containing the errors messages.
      *

--- a/src/getRequestValue.php
+++ b/src/getRequestValue.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("getRequestValue")) {
+if (!function_exists("Folded\getRequestValue")) {
     /**
      * Get a single value by its key from the request.
      *

--- a/src/hasRequestValue.php
+++ b/src/hasRequestValue.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 use Folded\Request;
 
-if (!function_exists("hasRequestValue")) {
+if (!function_exists("Folded\hasRequestValue")) {
     /**
      * Returns true if the request contains the value, else returns false.
      *

--- a/src/requestValidationSucceeded.php
+++ b/src/requestValidationSucceeded.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("requestValidationSucceeded")) {
+if (!function_exists("Folded\requestValidationSucceeded")) {
     /**
      * Returns true if the last validation succeeded, else returns false.
      *

--- a/src/setRequestValidationLang.php
+++ b/src/setRequestValidationLang.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("setRequestValidationLang")) {
+if (!function_exists("Folded\setRequestValidationLang")) {
     /**
      * Set the lang that is used to return the validation error messages.
      * By default, the "en" lang is used.

--- a/src/setRequestValidationTranslationFolderPath.php
+++ b/src/setRequestValidationTranslationFolderPath.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("setRequestValidationTranslationFolderPath")) {
+if (!function_exists("Folded\setRequestValidationTranslationFolderPath")) {
     /**
      * Set the translation folder path.
      *

--- a/src/storeOldRequestValues.php
+++ b/src/storeOldRequestValues.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("storeOldRequestValues")) {
+if (!function_exists("Folded\storeOldRequestValues")) {
     /**
      * Stores old forms values in session for further retrieval.
      *

--- a/src/validateRequest.php
+++ b/src/validateRequest.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("validateRequest")) {
+if (!function_exists("Folded\validateRequest")) {
     /**
      * Validate the request data.
      *


### PR DESCRIPTION
## Added

None.

## Fixed

- Bug when `function_exists` statements were missing the namespace `Folded`.

## Breaking

None.